### PR TITLE
Fix oscillating paddle at low framerates

### DIFF
--- a/js/player.js
+++ b/js/player.js
@@ -127,7 +127,10 @@ export class PlayerSystem extends System {
     this.paddleQuery.forEach((entity, paddle, body) => {
       if (this.useMouse) {
         const worldMouseX = ((mouse.position[0] / mouse.element.offsetWidth) - 0.5) * (BOARD_HALF_WIDTH * 3.5);
-        movement = Math.min(1, Math.max(-1, worldMouseX - paddle.x)) * delta * PADDLE_SPEED;
+        // Move toward the pointer by at most PADDLE_SPEED units/second, but clamped to the
+        // remaining distance so the paddle can't overshoot the target.
+        const maxStep = delta * PADDLE_SPEED;
+        movement = Math.max(-maxStep, Math.min(maxStep, worldMouseX - paddle.x));
       }
       paddle.x += movement;
 


### PR DESCRIPTION
While testing this on a less powerful mobile device, I observed an annoying flickering of the paddle after starting the game, even if no further input was given.
It seems that at low framerates (~20 fps in my case), the previous code can cause wild oscillations of the paddle.
Clamping the movement to the remaining delta prevents overshooting.
(I'm working on getting this game to run in [servo](github.com/servo/servo), so performance not being great is not that unexpected.)